### PR TITLE
Update reportid field in the comments table from the same field in the feature layer

### DIFF
--- a/CityworksConnection/connect_to_cityworks.py
+++ b/CityworksConnection/connect_to_cityworks.py
@@ -417,6 +417,11 @@ def main(event, context):
                     continue
                 else:
                     record.attributes[fc_flag] = flag_values[1]
+                    try:
+                        record.attributes[ids[1]] = parent.attributes[ids[1]]
+                    except TypeError:
+                        record.attributes[ids[1]] = str(parent.attributes[ids[1]])
+
                     updated_rows.append(record)
 
             # apply edits to updated records


### PR DESCRIPTION
Update the reportid field (Cityworks service request id) in the comments table from the same field in the feature layer.  The relationship definition should not be on the reportid field in the comments table anymore.  The primary key should be the GlobalID in the feature layer and the foreign key should be a GUID field in the comments table, just like the documentation suggests http://solutions.arcgis.com/local-government/help/crowdsource-reporter/get-started/create-layers/#comments.

This makes it possible to update/delete comments from Cityworks webhooks using just the reportid as the identifier.