### PR TITLE
support for no comments tables

### DIFF
--- a/CityworksConnection/Connect2Cityworks.pyt
+++ b/CityworksConnection/Connect2Cityworks.pyt
@@ -378,7 +378,8 @@ class Tool(object):
                     pass  # if no table/popup, no comments layer
 
             layer_urls = list(set(layer_urls))
-            table_urls = list(set(table_urls))
+            if len(table_urls) > 0:
+                table_urls = list(set(table_urls))
             flayers.filter.list = layer_urls
             flayers.value = layer_urls
             ftables.filter.list = table_urls
@@ -514,8 +515,12 @@ class Tool(object):
         layer_urls = [item.split(' ')[-1][1:-2] for item in str(flayers.value).split(';')]
         table_urls = [item.split(' ')[-1][1:-2] for item in str(ftables.value).split(';')]
         layer_fields = [[field[1], field[0]] for field in fl_flds.value]
-        table_fields = [[field[1], field[0]] for field in tb_flds.value]
-
+        table_fields = []
+        if tb_flds.value != None:
+            table_fields = [[field[1], field[0]] for field in tb_flds.value]
+        
+        if table_urls[0] == 'o':
+            table_urls = []
         cfg = {}
         cfg['cityworks'] = {'url': cw_url.value,
                             'username': cw_user.value,

--- a/CityworksConnection/connect_to_cityworks.py
+++ b/CityworksConnection/connect_to_cityworks.py
@@ -369,14 +369,17 @@ def main(event, context):
                     print("Status of updates to {}: {}".format(lyr.properties["name"], status))
 
             # related records
-            rellyr = FeatureLayer(reltable, gis=gis)
-            relname = rellyr.properties['name']
+            rel_records = []
+            #if comments tables aren't used, script will crash here
+            if len(lyr.properties.relationships) > 0:            
+                rellyr = FeatureLayer(reltable, gis=gis)
+                relname = rellyr.properties['name']
 
-            pkey_fld = lyr.properties.relationships[0]["keyField"]
-            fkey_fld = rellyr.properties.relationships[0]["keyField"]
-            sql = "{}='{}'".format(fc_flag, flag_values[0])
-            rel_records = rellyr.query(where=sql)
-            updated_rows = []
+                pkey_fld = lyr.properties.relationships[0]["keyField"]
+                fkey_fld = rellyr.properties.relationships[0]["keyField"]
+                sql = "{}='{}'".format(fc_flag, flag_values[0])
+                rel_records = rellyr.query(where=sql)
+                updated_rows = []
 
             for record in rel_records:
                 rel_oid = record.attributes[oid_fld]


### PR DESCRIPTION
If the solution is being built manually and not with the Solution Deployment tool, it's possible the client won't be using comments / related tables. When this is the case, the ArcGIS Pro tool wasn't able to generate a config file. If the client generated one manually and then used it, the connect_to_cityworks.py script would crash because it looks for relationships when there are none.